### PR TITLE
Add weekly earnings analyzer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ChatGPT-test
-chatgpt.com/codex test
 
-This repository contains a simple HTML portfolio page for demonstration.
-Open `portfolio.html` in a web browser to view the example page.
+This repository contains example HTML files.
+
+## Portfolio
+Open `portfolio.html` in a web browser to view the sample portfolio page.
+
+## Weekly Earnings Analyzer
+Open `index.html` in a browser to analyze weekly earnings from a CSV file. Upload your `Pending_Payouts.csv`, select a starting date, and click **Analyze** to see the report.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Weekly Earnings Analyzer</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+</head>
+<body>
+  <div class="container">
+    <h1>Weekly Earnings Analyzer</h1>
+    <div class="controls">
+      <label for="csvFile">Upload CSV:</label>
+      <input type="file" id="csvFile" accept=".csv">
+
+      <label for="startDate">Select starting date:</label>
+      <input type="date" id="startDate">
+
+      <button id="analyzeBtn">Analyze</button>
+    </div>
+    <div id="results"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,141 @@
+function parseDuration(str) {
+  if (!str) return 0;
+  let total = 0;
+  const h = str.match(/(\d+)h/);
+  const m = str.match(/(\d+)m/);
+  const s = str.match(/(\d+)s/);
+  if (h) total += parseInt(h[1], 10) * 3600;
+  if (m) total += parseInt(m[1], 10) * 60;
+  if (s) total += parseInt(s[1], 10);
+  return total;
+}
+
+function formatDuration(sec) {
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function formatCurrency(num) {
+  return `$${num.toFixed(2)}`;
+}
+
+function analyze(csvData, startDate) {
+  const start = new Date(startDate);
+  const day = start.getDay();
+  const diff = (day + 7 - 2) % 7; // difference to Tuesday
+  const weekStart = new Date(start);
+  weekStart.setDate(start.getDate() - diff);
+
+  const days = [];
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + i);
+    days.push({
+      date,
+      prepay: 0,
+      overtime: 0,
+      payout: 0,
+      tasks: 0,
+    });
+  }
+
+  csvData.forEach(row => {
+    const d = new Date(row.workDate);
+    const idx = Math.floor((d - weekStart) / (24 * 3600 * 1000));
+    if (idx >= 0 && idx < 7) {
+      const dayObj = days[idx];
+      const duration = parseDuration(row.duration);
+      if (row.payType === 'prepay') {
+        dayObj.prepay += duration;
+        dayObj.tasks += 1;
+      } else if (row.payType === 'overtimePay') {
+        dayObj.overtime += duration;
+      }
+      const payout = parseFloat(row.payout.replace(/[$]/g, ''));
+      if (!isNaN(payout)) dayObj.payout += payout;
+    }
+  });
+
+  return { weekStart, days };
+}
+
+function renderTable(result) {
+  if (!result) return;
+  const table = document.createElement('table');
+  const header = document.createElement('tr');
+  ['Day', 'Prepay Time', 'Overtime', 'Combined', 'Payout (USD)', 'Payout (EGP)', 'Task Count']
+    .forEach(text => {
+      const th = document.createElement('th');
+      th.textContent = text;
+      header.appendChild(th);
+    });
+  table.appendChild(header);
+
+  const totals = { prepay: 0, overtime: 0, payout: 0, tasks: 0 };
+
+  result.days.forEach(d => {
+    const tr = document.createElement('tr');
+    const combined = d.prepay + d.overtime;
+    totals.prepay += d.prepay;
+    totals.overtime += d.overtime;
+    totals.payout += d.payout;
+    totals.tasks += d.tasks;
+
+    const cells = [
+      d.date.toDateString(),
+      formatDuration(d.prepay),
+      formatDuration(d.overtime),
+      formatDuration(combined),
+      formatCurrency(d.payout),
+      formatCurrency(d.payout * 50),
+      d.tasks,
+    ];
+    cells.forEach(c => {
+      const td = document.createElement('td');
+      td.textContent = c;
+      tr.appendChild(td);
+    });
+    table.appendChild(tr);
+  });
+
+  const summary = document.createElement('tr');
+  summary.className = 'summary-row';
+  const combinedTotal = totals.prepay + totals.overtime;
+  const cells = [
+    'WEEK TOTAL',
+    formatDuration(totals.prepay),
+    formatDuration(totals.overtime),
+    formatDuration(combinedTotal),
+    formatCurrency(totals.payout),
+    formatCurrency(totals.payout * 50),
+    totals.tasks,
+  ];
+  cells.forEach(c => {
+    const td = document.createElement('td');
+    td.textContent = c;
+    summary.appendChild(td);
+  });
+  table.appendChild(summary);
+
+  const resultsDiv = document.getElementById('results');
+  resultsDiv.innerHTML = '';
+  resultsDiv.appendChild(table);
+}
+
+function handleAnalyze() {
+  const fileInput = document.getElementById('csvFile');
+  const dateInput = document.getElementById('startDate');
+  if (!fileInput.files.length || !dateInput.value) return;
+
+  Papa.parse(fileInput.files[0], {
+    header: true,
+    skipEmptyLines: true,
+    complete: function(res) {
+      const result = analyze(res.data, dateInput.value);
+      renderTable(result);
+    }
+  });
+}
+
+document.getElementById('analyzeBtn').addEventListener('click', handleAnalyze);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,63 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f6f8;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 800px;
+  margin: auto;
+  padding: 20px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.controls {
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.controls label {
+  margin-right: 5px;
+}
+
+button {
+  padding: 8px 16px;
+  background-color: #4CAF50;
+  border: none;
+  color: white;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #45a049;
+}
+
+#results table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#results th, #results td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: center;
+}
+
+#results th {
+  background-color: #f2f2f2;
+}
+
+.summary-row {
+  background-color: yellow;
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  .controls {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive web app to analyze weekly earnings
- highlight the weekly total row in yellow
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ca534fbb48330be8373650a4243a3