### PR TITLE
Fix date display misalignment

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -22,6 +22,10 @@ function formatCurrency(num) {
   return `$${num.toFixed(2)}`;
 }
 
+function formatDateUTC(date) {
+  return date.toISOString().split('T')[0];
+}
+
 
 function parseWorkDate(str) {
   if (!str) return null;
@@ -92,8 +96,8 @@ function ResultsTable({ result }) {
     totals.tasks += d.tasks;
 
     return (
-      <tr key={d.date.toDateString()}>
-        <td>{d.date.toDateString()}</td>
+      <tr key={formatDateUTC(d.date)}>
+        <td>{formatDateUTC(d.date)}</td>
         <td>{formatDuration(d.prepay)}</td>
         <td>{formatDuration(d.overtime)}</td>
         <td>{formatDuration(combined)}</td>


### PR DESCRIPTION
## Summary
- display dates using UTC formatting so entries don't shift by timezone

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9146d52c8330bc66a1e1bafed3d3